### PR TITLE
change git to use gitCmd instead of gitaneCmd

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -16,7 +16,12 @@ module.exports = {
     cb(null, {
       deploy: function (context, done) {
         var cmd = 'git push -f ' + config.app.git_url + ' ' + context.branch + ':master'
-        git.gitaneCmd(cmd, context.dataDir, account.privkey, context, done)
+         , auth = {
+            type: /^http/.test(config.app.git_url) ? 'http': 'ssh'
+            , privKey: account.privKey
+          }
+        git.gitCmd(cmd, context.dataDir, auth, context, done)
+
       }
     })
   }


### PR DESCRIPTION
Heroku changed (not sure when) their API to return http format git_url for an app.  It used to return git@heroku.com: format
